### PR TITLE
 ampleswap add router for showing liquidity 

### DIFF
--- a/dapps/evm/ampleswap/config.json
+++ b/dapps/evm/ampleswap/config.json
@@ -1,0 +1,15 @@
+[
+  {
+    "chain_id": 56,
+    "name": "ampleswap",
+    "type": "ampleswap",
+    "enabled": true,
+    "contracts": {
+      "AmpleToken": "0x19857937848c02afbde8b526610f0f2f89e9960d",
+      "Router": "0x7f1f846bc6b252bdee65f61491a879f0ad7ee926",
+      "Factory": "0x381fefadab5466bff0e8e96842e8e76a143e8f73",
+      "MasterChef": "0xf5987603323aa99dde0777a55e83c82d59cca272"
+    }
+	
+	  }
+]


### PR DESCRIPTION
Liquidity is less visible to me in Dex Guru, you added router Panchkeswap and Babidogeshwap only

please add ampleswap router for showing better liquidity

details
Url: https://ampleswap.com/
router: https://bscscan.com/address/0x7f1f846bc6b252bdee65f61491a879f0ad7ee926
token: https://bscscan.com/token/0x19857937848c02afbde8b526610f0f2f89e9960d


### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Blockchain Submissions:
We'll need the following to integrate your **EVM-compatible** blockchain: 

- [ ] At least one AMM on your chain with a daily volume over $100k. Do you include it in your PR?   
- [ ] Your chain logo
- [ ] Your native token logo
- [ ] Blockexplorer that could open account and transactions pages 
- [ ] High-performance RPC endpoint. Raise the issue in this repo or reach out our team at [Discord](https://discord.com/invite/dPW8fzwzz9) with access details.  


### New AMM Submissions:
We'll need the following to integrate your AMM: 

* [ ] Do you have a daily trading volume over $20k? 
* [ ] Does "type" at AMM config match your code base? 
* [ ] Your AMM logo. Please add a link to your logo or attach it to a new issue in this repo.  
